### PR TITLE
Update Minecraft wiki link to new domain

### DIFF
--- a/mc-server-wrapper-lib/src/communication.rs
+++ b/mc-server-wrapper-lib/src/communication.rs
@@ -44,7 +44,7 @@ pub enum ServerCommand {
     /// Send a message to all players on the server
     ///
     /// Message should be JSON of the following format:
-    /// https://minecraft.gamepedia.com/Raw_JSON_text_format
+    /// https://minecraft.wiki/w/Raw_JSON_text_format
     TellRawAll(String),
     /// Write the given string to the server's stdin as a command
     ///


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates the old wiki link accordingly.